### PR TITLE
work around first time setup issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A template for kick starting a Cloudflare Workers project",
   "module": "./dist/index.mjs",
   "scripts": {
-    "build": "rollup -c",
+    "build": "npm install && rollup -c",
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write '**/*.{js,css,json,md}'"
   },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,8 +6,11 @@ route = ""
 zone_id = ""
 
 [builder_config]
+# "npm install && npm run build" won't work here, && will be treated as an arg to npm install
 build_command = "npm run build"
 upload_format = "modules"
+src_dir = "src"
+build_dir = "dist"
 
 [durable_objects]
 implements = [{class_name = "Counter", namespace_name = "Counter"}]


### PR DESCRIPTION
Two specific issues this is working around are 
- npm modules not being installed before wrangler publish
- defaults for missing src / build  being rewritten in the generated toml to the full path generate was run from, not the path the project is actually in

My guess is other people are going to get bitten by the argument to build_command being treated as a single command rather than passed through to the shell... not sure how much we can reasonably do about that though.  